### PR TITLE
Description field width

### DIFF
--- a/geocoder/geocoder.json
+++ b/geocoder/geocoder.json
@@ -37,7 +37,13 @@
         "https"
     ],
     "produces": [
-        "application/json","application/vnd.geo+json","application/vnd.google-earth.kml+xml","application/xhtml+xml","application/gml+xml","text/csv","application/zip"
+        "application/json",
+        "application/vnd.geo+json",
+        "application/vnd.google-earth.kml+xml",
+        "application/xhtml+xml",
+        "application/gml+xml",
+        "text/csv",
+        "application/zip"
     ],
     "paths": {
         "/addresses.{outputFormat}": {
@@ -298,7 +304,7 @@
                     {
                         "name": "bbox",
                         "in": "query",
-                        "description": "Example: -126.0792945083648,49.76287332290923,-126.0163386310997,49.79077056256354 .  A bounding box (xmin,ymin,xmax,ymax) that limits the search area. See <a href=https://github.com/bcgov/api-specs/blob/master/geocoder/glossary.md#bbox target=\"_blank\">bbox</a>",
+                        "description": "Example: -126.07929,49.7628,-126.0163,49.7907.  A bounding box (xmin,ymin,xmax,ymax) that limits the search area. See <a href=https://github.com/bcgov/api-specs/blob/master/geocoder/glossary.md#bbox target=\"_blank\">bbox</a>",
                         "type": "string",
                         "required": false
                     },
@@ -460,7 +466,7 @@
                         "description": "Example: street,locality.  A comma separated list of individual match precision levels to include in results. See <a href=https://github.com/bcgov/api-specs/blob/master/geocoder/glossary.md#matchPrecision target=\"_blank\">matchPrecision</a>",
                         "type": "string",
                         "required": false,
-                        "default":"OCCUPANT"
+                        "default": "OCCUPANT"
                     },
                     {
                         "name": "matchPrecisionNot",
@@ -602,7 +608,7 @@
                     {
                         "name": "bbox",
                         "in": "query",
-                        "description": "Example: -126.0792945083648,49.76287332290923,-126.0163386310997,49.79077056256354 .  A bounding box (xmin,ymin,xmax,ymax) that limits the search area. See <a href=https://github.com/bcgov/api-specs/blob/master/geocoder/glossary.md#bbox target=\"_blank\">bbox</a>",
+                        "description": "Example: -126.07929,49.7628,-126.0163,49.7907.  A bounding box (xmin,ymin,xmax,ymax) that limits the search area. See <a href=https://github.com/bcgov/api-specs/blob/master/geocoder/glossary.md#bbox target=\"_blank\">bbox</a>",
                         "type": "string",
                         "required": false
                     },


### PR DESCRIPTION
Changes made to 2x description lines as described in the issue link below. This results in the description field no longer being cut off.

https://github.com/bcgov/DBC-APIM/issues/30