### PR TITLE
Updated OGL and API Terms of Use Links to Permalinks

### DIFF
--- a/bclaws/bclaws.json
+++ b/bclaws/bclaws.json
@@ -8,7 +8,7 @@
             "name": "Queen's Printer License",
             "url": "http://www.bclaws.ca/standards/2014/QP-License_1.0.html"
         },
-        "termsOfService": "http://www.data.gov.bc.ca/local/dbc/docs/license/API_Terms_of_Use.pdf"
+        "termsOfService": "http://www2.gov.bc.ca/gov/content?id=D1EE0A405E584363B205CD4353E02C88"
     },
     "externalDocs": {
         "description": "BCLaws API Documentation",

--- a/open511/open511.json
+++ b/open511/open511.json
@@ -6,9 +6,9 @@
         "version": "1.0.0",
         "license": {
             "name": "Open Government License - British Columbia",
-            "url": "http://www.data.gov.bc.ca/local/dbc/docs/license/OGL-vbc2.0.pdf"
+            "url": "http://www2.gov.bc.ca/gov/content?id=A519A56BC2BF44E4A008B33FCF527F61"
         },
-        "termsOfService": "http://www.data.gov.bc.ca/local/dbc/docs/license/API_Terms_of_Use.pdf",
+        "termsOfService": "http://www2.gov.bc.ca/gov/content?id=D1EE0A405E584363B205CD4353E02C88",
         "contact": {
             "name": "Drive BC",
             "url": "http://www.drivebc.ca/",

--- a/router/router.json
+++ b/router/router.json
@@ -8,7 +8,7 @@
             "name": "Copyright 2016 Province of British Columbia - Access only",
             "url": "http://www2.gov.bc.ca/gov/content/home/copyright"
         },
-        "termsOfService": "http://www.data.gov.bc.ca/local/dbc/docs/license/API_Terms_of_Use.pdf",
+        "termsOfService": "http://www2.gov.bc.ca/gov/content?id=D1EE0A405E584363B205CD4353E02C88",
         "contact": {
             "name": "Data BC",
             "url": "https://forms.gov.bc.ca/databc-contact-us/",


### PR DESCRIPTION
Hello, these changes correspond to JIRA ticket TH-22543.

I was tasked to change any Open 511 links regarding the _Open Government Licence_ and _API Terms of Use_ pages.

I went through the api-specs repository and found any old URLs for the _Open Government Licence_ and _API Terms of Use_. I came across some _API Terms of Use_ links that could be updated in  bclaws/bclaws.json and router/router.json as well.

The old links should be changed to the following permalinks:

OGL-BC
Page permalink: http://www2.gov.bc.ca/gov/content?id=A519A56BC2BF44E4A008B33FCF527F61
 
API Terms of Use for OGL-BC Information
Page permalink: http://www2.gov.bc.ca/gov/content?id=D1EE0A405E584363B205CD4353E02C88
 
Let me know if you have any questions or concerns,

Kathy
