### PR TITLE
removed top-level 'tags' that weren't assigned to any paths.  

### DIFF
--- a/router/router.json
+++ b/router/router.json
@@ -24,23 +24,11 @@
             "name": "directions"
         },
         {
-            "name": "routes"
-        },
-        {
             "name": "route"
         },
         {
-            "name": "routing"
+            "name": "distance"
         },
-        {
-            "name": "route planning"
-        },
-        {
-            "name": "shortest route"
-        },
-        {
-            "name": "fastest route"
-        }
     ],
     "host": "router.api.gov.bc.ca",
     "basePath": "/",


### PR DESCRIPTION
swagger-ui renders the unused tags on the API Console as empty containers that may confuse users.