### PR TITLE
Added partitioning to router.json

### DIFF
--- a/router/router.json
+++ b/router/router.json
@@ -2420,7 +2420,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck route sections and non-truck route sections, ferry sections and non-ferry sections, and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck route sections and non-truck route sections <br> isFerry – Distinguish between ferry sections and non-ferry sections <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -2568,7 +2568,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck route sections and non-truck route sections, ferry sections and non-ferry sections, and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck route sections and non-truck route sections <br> isFerry – Distinguish between ferry sections and non-ferry sections <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -2718,7 +2718,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck route sections and non-truck route sections, ferry sections and non-ferry sections, and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck route sections and non-truck route sections <br> isFerry – Distinguish between ferry sections and non-ferry sections <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -2866,7 +2866,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck route sections and non-truck route sections, ferry sections and non-ferry sections, and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck route sections and non-truck route sections <br> isFerry – Distinguish between ferry sections and non-ferry sections <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -3016,7 +3016,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck route sections and non-truck route sections, ferry sections and non-ferry sections, and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck route sections and non-truck route sections <br> isFerry – Distinguish between ferry sections and non-ferry sections <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -3164,7 +3164,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck route sections and non-truck route sections, ferry sections and non-ferry sections, and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck route sections and non-truck route sections <br> isFerry – Distinguish between ferry sections and non-ferry sections <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -3314,7 +3314,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck route sections and non-truck route sections, ferry sections and non-ferry sections, and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck route sections and non-truck route sections <br> isFerry – Distinguish between ferry sections and non-ferry sections <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -3462,7 +3462,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck route sections and non-truck route sections, ferry sections and non-ferry sections, and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck route sections and non-truck route sections <br> isFerry – Distinguish between ferry sections and non-ferry sections <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",

--- a/router/router.json
+++ b/router/router.json
@@ -1846,6 +1846,16 @@
             }
           },
           {
+            "name": "partition",
+            "in": "query",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "isTruckRoute,isFerry,locality"
+            }
+          },
+          {
             "name": "disable",
             "in": "query",
             "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
@@ -1981,6 +1991,16 @@
             "schema": {
               "type": "boolean",
               "default": false
+            }
+          },
+          {
+            "name": "partition",
+            "in": "query",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "isTruckRoute,isFerry,locality"
             }
           },
           {
@@ -2418,6 +2438,16 @@
             }
           },
           {
+            "name": "partition",
+            "in": "query",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "isTruckRoute,isFerry,locality"
+            }
+          },
+          {
             "name": "disable",
             "in": "query",
             "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br> Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
@@ -2553,6 +2583,16 @@
             "schema": {
               "type": "boolean",
               "default": false
+            }
+          },
+          {
+            "name": "partition",
+            "in": "query",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "isTruckRoute,isFerry,locality"
             }
           },
           {

--- a/router/router.json
+++ b/router/router.json
@@ -2698,7 +2698,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Will distibguish between truck routes and non-truck routes <br> isFerry – Will identify portions of the route that use a ferry. <br> locality – Will include the locality name for the route partition.",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distibguish between truck routes and non-truck routes <br> isFerry – Identify portions of the route that use a ferry. <br> locality – Include the locality name for the route partition.",
             "required": false,
             "schema": {
               "type": "string",

--- a/router/router.json
+++ b/router/router.json
@@ -164,7 +164,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -302,7 +302,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -441,7 +441,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -587,7 +587,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -874,7 +874,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -1014,7 +1014,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -1152,7 +1152,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -1292,7 +1292,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -1430,7 +1430,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -1570,7 +1570,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -1708,7 +1708,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -1848,7 +1848,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -1986,7 +1986,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -2125,7 +2125,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -2271,7 +2271,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -2578,7 +2578,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -2728,7 +2728,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -2876,7 +2876,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -3026,7 +3026,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -3174,7 +3174,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -3324,7 +3324,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",
@@ -3472,7 +3472,7 @@
           {
             "name": "disable",
             "in": "query",
-            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
+            "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
             "required": false,
             "schema": {
               "type": "string",

--- a/router/router.json
+++ b/router/router.json
@@ -1846,16 +1846,6 @@
             }
           },
           {
-            "name": "partition",
-            "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "isTruckRoute,isFerry,locality"
-            }
-          },
-          {
             "name": "disable",
             "in": "query",
             "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
@@ -1991,16 +1981,6 @@
             "schema": {
               "type": "boolean",
               "default": false
-            }
-          },
-          {
-            "name": "partition",
-            "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "isTruckRoute,isFerry,locality"
             }
           },
           {

--- a/router/router.json
+++ b/router/router.json
@@ -2420,7 +2420,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -2568,7 +2568,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -2718,7 +2718,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -2866,7 +2866,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -3016,7 +3016,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -3164,7 +3164,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -3314,7 +3314,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",
@@ -3462,7 +3462,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",

--- a/router/router.json
+++ b/router/router.json
@@ -2698,7 +2698,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distibguish between truck routes and non-truck routes <br> isFerry – Identify portions of the route that use a ferry. <br> locality – Include the locality name for the route partition.",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
             "required": false,
             "schema": {
               "type": "string",

--- a/router/router.json
+++ b/router/router.json
@@ -2424,7 +2424,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "isTruckRoute,isFerry,locality"
+              "default": ""
             }
           },
           {
@@ -2572,7 +2572,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "isTruckRoute,isFerry,locality"
+              "default": ""
             }
           },
           {
@@ -2722,7 +2722,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "isTruckRoute,isFerry,locality"
+              "default": ""
             }
           },
           {
@@ -2870,7 +2870,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "isTruckRoute,isFerry,locality"
+              "default": ""
             }
           },
           {
@@ -3020,7 +3020,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "isTruckRoute,isFerry,locality"
+              "default": ""
             }
           },
           {
@@ -3168,7 +3168,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "isTruckRoute,isFerry,locality"
+              "default": ""
             }
           },
           {
@@ -3318,7 +3318,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "isTruckRoute,isFerry,locality"
+              "default": ""
             }
           },
           {
@@ -3466,7 +3466,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "isTruckRoute,isFerry,locality"
+              "default": ""
             }
           },
           {

--- a/router/router.json
+++ b/router/router.json
@@ -2696,6 +2696,16 @@
             }
           },
           {
+            "name": "partition",
+            "in": "query",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes and locality names. Any or all of the following values can be used.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. <br>Partition values:<br> isTruckRoute – Will distibguish between truck routes and non-truck routes <br> isFerry – Will identify portions of the route that use a ferry. <br> locality – Will include the locality name for the route partition.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "isTruckRoute,isFerry,locality"
+            }
+          },
+          {
             "name": "disable",
             "in": "query",
             "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",

--- a/router/router.json
+++ b/router/router.json
@@ -2844,6 +2844,16 @@
             }
           },
           {
+            "name": "partition",
+            "in": "query",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "isTruckRoute,isFerry,locality"
+            }
+          },
+          {
             "name": "disable",
             "in": "query",
             "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
@@ -2984,6 +2994,16 @@
             }
           },
           {
+            "name": "partition",
+            "in": "query",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "isTruckRoute,isFerry,locality"
+            }
+          },
+          {
             "name": "disable",
             "in": "query",
             "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
@@ -3119,6 +3139,16 @@
             "schema": {
               "type": "boolean",
               "default": false
+            }
+          },
+          {
+            "name": "partition",
+            "in": "query",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "isTruckRoute,isFerry,locality"
             }
           },
           {
@@ -3262,6 +3292,16 @@
             }
           },
           {
+            "name": "partition",
+            "in": "query",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "isTruckRoute,isFerry,locality"
+            }
+          },
+          {
             "name": "disable",
             "in": "query",
             "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",
@@ -3397,6 +3437,16 @@
             "schema": {
               "type": "boolean",
               "default": false
+            }
+          },
+          {
+            "name": "partition",
+            "in": "query",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes, non-ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck routes and non-truck routes <br> isFerry – Distinguish between ferry routes and non-ferry routes. <br> locality – Include the locality name for the route partition",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "isTruckRoute,isFerry,locality"
             }
           },
           {

--- a/router/router.json
+++ b/router/router.json
@@ -2698,7 +2698,7 @@
           {
             "name": "partition",
             "in": "query",
-            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes and locality names. Any or all of the following values can be used.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. <br>Partition values:<br> isTruckRoute – Will distibguish between truck routes and non-truck routes <br> isFerry – Will identify portions of the route that use a ferry. <br> locality – Will include the locality name for the route partition.",
+            "description": "A comma-separated list of values to identify sections of the route that correspond to truck routes, non-truck routes, ferry routes and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Will distibguish between truck routes and non-truck routes <br> isFerry – Will identify portions of the route that use a ferry. <br> locality – Will include the locality name for the route partition.",
             "required": false,
             "schema": {
               "type": "string",


### PR DESCRIPTION
Updated the BC Route Planner API specification to include partitioning (truck/ferry/locality) for truck routing endpoints. The default value for 'partition' will remain blank (in the API spec) until a default value is configured in the API itself.

Also added spacing to the disable item for readability. 