### PR TITLE
Router API spec - truckRouteMultiplier

### DIFF
--- a/router/router.json
+++ b/router/router.json
@@ -2418,6 +2418,16 @@
             }
           },
           {
+            "name": "truckRouteMultiplier",
+            "in": "query",
+            "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "9"
+            }
+          },
+          {
             "name": "partition",
             "in": "query",
             "description": "A comma-separated list of values to identify sections of the route that correspond to truck route sections and non-truck route sections, ferry sections and non-ferry sections, and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck route sections and non-truck route sections <br> isFerry – Distinguish between ferry sections and non-ferry sections <br> locality – Include the locality name for the route partition",
@@ -2563,6 +2573,16 @@
             "schema": {
               "type": "boolean",
               "default": false
+            }
+          },
+          {
+            "name": "truckRouteMultiplier",
+            "in": "query",
+            "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "9"
             }
           },
           {
@@ -2716,6 +2736,16 @@
             }
           },
           {
+            "name": "truckRouteMultiplier",
+            "in": "query",
+            "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "9"
+            }
+          },
+          {
             "name": "partition",
             "in": "query",
             "description": "A comma-separated list of values to identify sections of the route that correspond to truck route sections and non-truck route sections, ferry sections and non-ferry sections, and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck route sections and non-truck route sections <br> isFerry – Distinguish between ferry sections and non-ferry sections <br> locality – Include the locality name for the route partition",
@@ -2861,6 +2891,16 @@
             "schema": {
               "type": "boolean",
               "default": false
+            }
+          },
+          {
+            "name": "truckRouteMultiplier",
+            "in": "query",
+            "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "9"
             }
           },
           {
@@ -3014,6 +3054,16 @@
             }
           },
           {
+            "name": "truckRouteMultiplier",
+            "in": "query",
+            "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "9"
+            }
+          },
+          {
             "name": "partition",
             "in": "query",
             "description": "A comma-separated list of values to identify sections of the route that correspond to truck route sections and non-truck route sections, ferry sections and non-ferry sections, and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck route sections and non-truck route sections <br> isFerry – Distinguish between ferry sections and non-ferry sections <br> locality – Include the locality name for the route partition",
@@ -3159,6 +3209,16 @@
             "schema": {
               "type": "boolean",
               "default": false
+            }
+          },
+          {
+            "name": "truckRouteMultiplier",
+            "in": "query",
+            "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "9"
             }
           },
           {
@@ -3312,6 +3372,16 @@
             }
           },
           {
+            "name": "truckRouteMultiplier",
+            "in": "query",
+            "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "9"
+            }
+          },
+          {
             "name": "partition",
             "in": "query",
             "description": "A comma-separated list of values to identify sections of the route that correspond to truck route sections and non-truck route sections, ferry sections and non-ferry sections, and locality names.  The response includes a partitions attribute, which is an array of objects, each of which has an index (into the route coordinate array) and a value for each of the attributes requested in the partition parameter. Any or all of the following values can be used. <br><br>Partition values:<br> isTruckRoute – Distinguish between truck route sections and non-truck route sections <br> isFerry – Distinguish between ferry sections and non-ferry sections <br> locality – Include the locality name for the route partition",
@@ -3457,6 +3527,16 @@
             "schema": {
               "type": "boolean",
               "default": false
+            }
+          },
+          {
+            "name": "truckRouteMultiplier",
+            "in": "query",
+            "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "9"
             }
           },
           {

--- a/router/router.json
+++ b/router/router.json
@@ -1851,8 +1851,8 @@
             "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
             "required": false,
             "schema": {
-              "type": "string",
-              "default": "9"
+              "type": "integer",
+              "default": 9
             }
           },
           {
@@ -2433,8 +2433,8 @@
             "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
             "required": false,
             "schema": {
-              "type": "string",
-              "default": "9"
+              "type": "integer",
+              "default": 9
             }
           },
           {
@@ -2591,8 +2591,8 @@
             "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
             "required": false,
             "schema": {
-              "type": "string",
-              "default": "9"
+              "type": "integer",
+              "default": 9
             }
           },
           {
@@ -2751,8 +2751,8 @@
             "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
             "required": false,
             "schema": {
-              "type": "string",
-              "default": "9"
+              "type": "integer",
+              "default": 9
             }
           },
           {
@@ -2909,8 +2909,8 @@
             "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
             "required": false,
             "schema": {
-              "type": "string",
-              "default": "9"
+              "type": "integer",
+              "default": 9
             }
           },
           {
@@ -3069,8 +3069,8 @@
             "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
             "required": false,
             "schema": {
-              "type": "string",
-              "default": "9"
+              "type": "integer",
+              "default": 9
             }
           },
           {
@@ -3227,8 +3227,8 @@
             "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
             "required": false,
             "schema": {
-              "type": "string",
-              "default": "9"
+              "type": "integer",
+              "default": 9
             }
           },
           {
@@ -3387,8 +3387,8 @@
             "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
             "required": false,
             "schema": {
-              "type": "string",
-              "default": "9"
+              "type": "integer",
+              "default": 9
             }
           },
           {
@@ -3545,8 +3545,8 @@
             "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
             "required": false,
             "schema": {
-              "type": "string",
-              "default": "9"
+              "type": "integer",
+              "default": 9
             }
           },
           {

--- a/router/router.json
+++ b/router/router.json
@@ -1846,6 +1846,16 @@
             }
           },
           {
+            "name": "truckRouteMultiplier",
+            "in": "query",
+            "description": "The truck route multiplier value is used to multiply the cost of using roads that are not truck routes.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "9"
+            }
+          },
+          {
             "name": "disable",
             "in": "query",
             "description": "A comma-separated list of time-related modules to disable (e.g., sc,tf,ev,td).<br><br>Module names include:<br> sc – ferry schedules; disabled by default; disabled by default and only suitable for demos<br>tf – historic traffic congestion; disabled by default and only suitable for demos<br>ev – road events; disabled by default and only suitable for demos<br>td – time-dependency; disabling this disables sc, tf, and ev modules<br>tr – turn restrictions; if td is disabled, time-dependent turn restrictions are ignored<br>tc - turn costs (e.g., left turns take longer than right turns)",


### PR DESCRIPTION
The truckRouteMultiplier parameter has been added to the BC Route Planner API spec along with the current default integer value as listed in the code.