### PR TITLE
Update geocoder-combined.json

### DIFF
--- a/geocoder/geocoder-combined.json
+++ b/geocoder/geocoder-combined.json
@@ -57,8 +57,7 @@
         "summary": "Geocode an address",
         "description": "Represents the set of geocoded and standardized sites and intersections whose address best matches a given query address.",
         "tags": [
-          "sites",
-          "intersections"
+          "sites"
         ],
         "parameters": [
           {


### PR DESCRIPTION
The 'intersection' tag was removed from \addresses resource. Only the 'sites' tag is needed in this section of the Geocoder API specification.