### PR TITLE
exactSpelling parameter

### DIFF
--- a/geocoder/geocoder-combined.json
+++ b/geocoder/geocoder-combined.json
@@ -164,7 +164,7 @@
             }
           },
           {
-            "name": "exactSpelling",
+            "name": "exactSpelling (geocodertst)",
             "in": "query",
             "description": "If true, autoComplete suggestions are limited to addresses beginning with the provided partial address.",
             "required": false,
@@ -562,7 +562,7 @@
             }
           },
           {
-            "name": "exactSpelling",
+            "name": "exactSpelling (geocodertst)",
             "in": "query",
             "description": "If true, autoComplete suggestions are limited to addresses beginning with the provided partial address.",
             "required": false,

--- a/geocoder/geocoder-combined.json
+++ b/geocoder/geocoder-combined.json
@@ -164,6 +164,16 @@
             }
           },
           {
+            "name": "exactSpelling",
+            "in": "query",
+            "description": "If true, autoComplete suggestions are limited to addresses beginning with the provided partial address.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
             "name": "setBack",
             "in": "query",
             "description": "The distance to move the accessPoint away from the curb and towards the inside of the parcel (in metres). Ignored if locationDescriptor not set to accessPoint.",
@@ -545,6 +555,16 @@
             "name": "autoComplete",
             "in": "query",
             "description": "If true, addressString is expected to contain a partial address that requires completion. Not supported for shp, csv, gml formats.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "exactSpelling",
+            "in": "query",
+            "description": "If true, autoComplete suggestions are limited to addresses beginning with the provided partial address.",
             "required": false,
             "schema": {
               "type": "boolean",

--- a/geocoder/geocoder-combined.json
+++ b/geocoder/geocoder-combined.json
@@ -164,9 +164,9 @@
             }
           },
           {
-            "name": "exactSpelling (geocodertst)",
+            "name": "exactSpelling",
             "in": "query",
-            "description": "If true, autoComplete suggestions are limited to addresses beginning with the provided partial address.",
+            "description": "If true, autoComplete suggestions are limited to addresses beginning with the provided partial address (**only available in geocodertst**).",
             "required": false,
             "schema": {
               "type": "boolean",
@@ -562,9 +562,9 @@
             }
           },
           {
-            "name": "exactSpelling (geocodertst)",
+            "name": "exactSpelling",
             "in": "query",
-            "description": "If true, autoComplete suggestions are limited to addresses beginning with the provided partial address.",
+            "description": "If true, autoComplete suggestions are limited to addresses beginning with the provided partial address (**only available in geocodertst**).",
             "required": false,
             "schema": {
               "type": "boolean",


### PR DESCRIPTION
Added the exactSpelling parameter to the API console with an indication that it is only available on geocodertst. Will remove test label when migrated to PROD.