### PR TITLE
Geocoder API Spec update - GC 4.5.4

### DIFF
--- a/geocoder/geocoder-combined.json
+++ b/geocoder/geocoder-combined.json
@@ -2314,7 +2314,7 @@
         }
       }
     },
-    "/status": {
+    "/status.json": {
       "get": {
         "summary": "Get a data summary and list of any startup warnings or errors",
         "description": "Includes data vintage, address count, and details of any startup warning or errors",

--- a/geocoder/geocoder-combined.json
+++ b/geocoder/geocoder-combined.json
@@ -514,7 +514,7 @@
                 "and"
               ],
               "default": "or"
-            },
+            }
           },
           {
             "name": "locationDescriptor",

--- a/geocoder/geocoder-combined.json
+++ b/geocoder/geocoder-combined.json
@@ -94,6 +94,30 @@
             "example": "525 Superior Street, Victoria, BC"
           },
           {
+            "name": "preferredEncoding",
+            "in": "query",
+            "description": "Returns an ASCII alternative for a utf-8 street name, if one has been provided by the address authority.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ascii",
+                "extended-ascii",
+                "utf-8"
+              ],
+            }
+          },
+          {
+            "name": "hasPid",
+            "in": "query",
+            "description": "If true, only addresses with parcel IDs will be returned.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
             "name": "locationDescriptor",
             "in": "query",
             "description": "Describes the nature of the address location. See <a href=https://github.com/bcgov/ols-geocoder/blob/gh-pages/glossary.md#locationDescriptor target=\"_blank\">locationDescriptor</a>",

--- a/geocoder/geocoder-combined.json
+++ b/geocoder/geocoder-combined.json
@@ -24,7 +24,7 @@
     },
     "termsOfService": "https://www2.gov.bc.ca/gov/content?id=D1EE0A405E584363B205CD4353E02C88",
     "contact": {
-      "name": "Contact DataBC",
+      "name": "Contact the Location Services team",
       "url": "https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/7/"
     }
   },
@@ -44,6 +44,9 @@
     },
     {
       "name": "parcels"
+    },
+    {
+      "name": "status"
     }
   ],
   "security": [
@@ -2307,6 +2310,22 @@
         "responses": {
           "200": {
             "description": "A comma-separated string containing all the parcel identifiers associated with the requested siteID"
+          }
+        }
+      }
+    },
+    "/status": {
+      "get": {
+        "summary": "Get a data summary and list of any startup warnings or errors",
+        "description": "Includes data vintage, address count, and details of any startup warning or errors",
+        "tags": [
+          "status"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "A JSON response containing details on Geocoder data and any startup warning or errors"
           }
         }
       }


### PR DESCRIPTION
Updated the BC Address Geocoder API spec with the following:

1) Added a new preferredEncoding parameter that returns an ASCII alternative for a UTF-8 street name when one is provided by the address authority. Supported values are ascii, extended-ascii, and utf-8. The BC Address Geocoder continues to return utf-8 by default.
2) Added a new hasPid parameter. When set to true, only address matches with a PID are returned. The default value is false.
3) Added a new status endpoint that returns a data summary and any startup warnings or errors.